### PR TITLE
feat: integration-api: reconfigure integration driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Add `reconfigure` flag in `DriverSetupRequest` message to reconfigure a driver.
+
 ---
 
 ## v0.1.3 - 2023-11-08

--- a/examples/setup_flow.py
+++ b/examples/setup_flow.py
@@ -43,6 +43,10 @@ async def handle_driver_setup(
     :param msg: value(s) of input fields in the first setup screen.
     :return: the setup action on how to continue
     """
+    # No support for reconfiguration :-)
+    if msg.reconfigure:
+        print("Ignoring driver reconfiguration request")
+
     # For our demo we simply clear everything!
     # A real driver might have to handle this differently
     api.available_entities.clear()
@@ -51,6 +55,13 @@ async def handle_driver_setup(
     # check if user selected the expert option in the initial setup screen
     # please note that all values are returned as strings!
     if "expert" not in msg.setup_data or msg.setup_data["expert"] != "true":
+        # add a single button as default action
+        button = ucapi.Button(
+            "button",
+            "Button",
+            cmd_handler=cmd_handler,
+        )
+        api.available_entities.add(button)
         return ucapi.SetupComplete()
 
     # Dropdown selections are usually set dynamically, e.g. with found devices etc.

--- a/ucapi/api.py
+++ b/ucapi/api.py
@@ -508,7 +508,9 @@ class IntegrationAPI:
         result = False
         try:
             action = await self._setup_handler(
-                uc.DriverSetupRequest(msg_data["setup_data"])
+                uc.DriverSetupRequest(
+                    msg_data.get("reconfigure") or False, msg_data["setup_data"]
+                )
             )
 
             if isinstance(action, uc.RequestUserInput):

--- a/ucapi/api_definitions.py
+++ b/ucapi/api_definitions.py
@@ -118,6 +118,7 @@ class DriverSetupRequest(SetupDriver):
     identifier, value contains the input value.
     """
 
+    reconfigure: bool
     setup_data: dict[str, str]
 
 


### PR DESCRIPTION
Add `reconfigure` flag to reconfigure an already configured driver.