### PR TITLE
New media-player entity features and simple command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Media-player entity features ([core-api/#32](https://github.com/unfoldedcircle/core-api/issues/32)):
+    - new features: numpad, guide, info, eject, open_close, audio_track, subtitle, record.
+    - new option: simple_commands for any additional commands not covered by a feature.
+
 ### Changed
 - Add `reconfigure` flag in `DriverSetupRequest` message to reconfigure a driver.
 - Always notify clients when setting a new device state, even if the state doesn't change.

--- a/ucapi/media_player.py
+++ b/ucapi/media_player.py
@@ -52,12 +52,20 @@ class Features(str, Enum):
     MEDIA_IMAGE_URL = "media_image_url"
     MEDIA_TYPE = "media_type"
     DPAD = "dpad"
+    NUMPAD = "numpad"
     HOME = "home"
     MENU = "menu"
+    GUIDE = "guide"
+    INFO = "info"
     COLOR_BUTTONS = "color_buttons"
     CHANNEL_SWITCHER = "channel_switcher"
     SELECT_SOURCE = "select_source"
     SELECT_SOUND_MODE = "select_sound_mode"
+    EJECT = "eject"
+    OPEN_CLOSE = "open_close"
+    AUDIO_TRACK = "audio_track"
+    SUBTITLE = "subtitle"
+    RECORD = "record"
 
 
 class Attributes(str, Enum):
@@ -109,15 +117,34 @@ class Commands(str, Enum):
     CURSOR_LEFT = "cursor_left"
     CURSOR_RIGHT = "cursor_right"
     CURSOR_ENTER = "cursor_enter"
+    DIGIT_0 = "digit_0"
+    DIGIT_1 = "digit_1"
+    DIGIT_2 = "digit_2"
+    DIGIT_3 = "digit_3"
+    DIGIT_4 = "digit_4"
+    DIGIT_5 = "digit_5"
+    DIGIT_6 = "digit_6"
+    DIGIT_7 = "digit_7"
+    DIGIT_8 = "digit_8"
+    DIGIT_9 = "digit_9"
     FUNCTION_RED = "function_red"
     FUNCTION_GREEN = "function_green"
     FUNCTION_YELLOW = "function_yellow"
     FUNCTION_BLUE = "function_blue"
     HOME = "home"
     MENU = "menu"
+    GUIDE = "guide"
+    INFO = "info"
     BACK = "back"
     SELECT_SOURCE = "select_source"
     SELECT_SOUND_MODE = "select_sound_mode"
+    RECORD = "record"
+    MY_RECORDINGS = "my_recordings"
+    LIVE = "live"
+    EJECT = "eject"
+    OPEN_CLOSE = "open_close"
+    AUDIO_TRACK = "audio_track"
+    SUBTITLE = "subtitle"
     SEARCH = "search"
 
 
@@ -134,6 +161,7 @@ class DeviceClasses(str, Enum):
 class Options(str, Enum):
     """Media-player entity options."""
 
+    SIMPLE_COMMANDS = "simple_commands"
     VOLUME_STEPS = "volume_steps"
 
 


### PR DESCRIPTION
Additional media-player features: numpad, guide, info, eject, open_close, audio_track, subtitle, record.
New `simple_commands` option for any additional commands not covered by a feature.

Relates to:
- https://github.com/unfoldedcircle/core-api/issues/32

Required for:
- https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/56
- https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/92
