### PR TITLE
refactor: filter out base64 encoded image fields in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Filter out base64 encoded media-player image fields in log messages ([#17](https://github.com/unfoldedcircle/integration-python-library/issues/17)).
+
 ---
 
 ## v0.1.6 - 2024-03-04


### PR DESCRIPTION
- Replace base64 encoded image data in `media_image_url` media-player attribute fields in log messages with `***`.
- Optimize json dump: only dump once for multiple clients.
- Only log and filter messages if DEBUG level is active.

Closes #17