### PR TITLE
fix: filter log messages may not modify original data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# GitHub Action to run unit tests
+---
+name: "Unit tests"
+
+on:
+  push:
+    paths:
+      - 'tests/**'
+      - 'ucapi/**'
+      - 'requirements.txt'
+      - 'test-requirements.txt'
+      - '.github/**/*.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pip
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Unit tests
+        run: |
+          python -m unittest discover tests

--- a/.idea/runConfigurations/Unit_tests.xml
+++ b/.idea/runConfigurations/Unit_tests.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit tests" type="tests" factoryName="Autodetect">
+    <module name="integration-python-library" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/tests" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <EXTENSION ID="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+      </ENTRIES>
+    </EXTENSION>
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;$PROJECT_DIR$/tests/&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,95 @@
+import unittest
+from copy import deepcopy
+
+from ucapi.api import filter_log_msg_data
+from ucapi.media_player import Attributes
+
+
+class TestFilterLogMsgData(unittest.TestCase):
+
+    def test_no_modification_when_no_msg_data(self):
+        data = {}
+        result = filter_log_msg_data(data)
+        self.assertEqual(result, {}, "The result should be an empty dictionary")
+
+    def test_no_changes_when_media_image_url_not_present(self):
+        data = {"msg_data": {"attributes": {"state": "playing", "volume": 50}}}
+        original = deepcopy(data)
+
+        result = filter_log_msg_data(data)
+
+        self.assertEqual(
+            result,
+            original,
+            "The result should be the same as the input when no filtered attributes are present",
+        )
+
+    def test_filtering_media_image_url_in_dict(self):
+        data = {
+            "msg_data": {
+                "attributes": {
+                    "state": "playing",
+                    Attributes.MEDIA_IMAGE_URL: "data:image/png;base64,encodeddata",
+                }
+            }
+        }
+        expected_result = deepcopy(data)
+        expected_result["msg_data"]["attributes"][
+            Attributes.MEDIA_IMAGE_URL
+        ] = "data:***"
+
+        result = filter_log_msg_data(data)
+
+        self.assertEqual(
+            result, expected_result, "The MEDIA_IMAGE_URL attribute should be filtered"
+        )
+
+    def test_filtering_media_image_url_in_list(self):
+        data = {
+            "msg_data": [
+                {
+                    "attributes": {
+                        "state": "paused",
+                        Attributes.MEDIA_IMAGE_URL: "data:image/png;base64,exampledata",
+                    }
+                },
+                {
+                    "attributes": {
+                        "state": "playing",
+                        Attributes.MEDIA_IMAGE_URL: "data:image/jpg;base64,exampledata",
+                    }
+                },
+                {"attributes": {"state": "stopped"}},
+            ]
+        }
+        expected_result = deepcopy(data)
+        expected_result["msg_data"][0]["attributes"][
+            Attributes.MEDIA_IMAGE_URL
+        ] = "data:***"
+        expected_result["msg_data"][1]["attributes"][
+            Attributes.MEDIA_IMAGE_URL
+        ] = "data:***"
+
+        result = filter_log_msg_data(data)
+
+        self.assertEqual(
+            result,
+            expected_result,
+            "All MEDIA_IMAGE_URL attributes in the list should be filtered",
+        )
+
+    def test_input_is_not_modified(self):
+        data = {
+            "msg_data": {
+                "attributes": {
+                    Attributes.MEDIA_IMAGE_URL: "data:image/png;base64,encodeddata"
+                }
+            }
+        }
+        original_data = deepcopy(data)
+
+        filter_log_msg_data(data)
+
+        self.assertEqual(
+            data, original_data, "The input data should not be modified by the function"
+        )


### PR DESCRIPTION
Fix `filter_log_msg_data` function to not modify passed in message data:

- The first WS message is not affected, json to text dump is done before.
- But since no deep copy is made on the input data, the original data is still affected.
- The original data is usually the internally stored entity.
- The modified data is returned if the Remote requests the entity data!