### PR TITLE
IR Emitter

### DIFF
--- a/ucapi/entity.py
+++ b/ucapi/entity.py
@@ -26,6 +26,7 @@ class EntityTypes(str, Enum):
     REMOTE = "remote"
     SENSOR = "sensor"
     SWITCH = "switch"
+    IR_EMITTER = "ir_emitter"
 
 
 class Entity:


### PR DESCRIPTION
One liner to add IR_EMITTER to the list of supported EntityTypes. 

You can almost get away with passing in a string but  line 76 `_LOG.debug("Created %s entity: %s", self.entity_type.value, self.id)` is expecting an Enum. So you have to define a local EntityTypes Enum and pass that in to keep things moving which felt like just enough to open a pull request. :)

Keep up the great work! 