### PR TITLE
refactor!: WS client disconnection may not emit a disconnect event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Breaking Changes
+- A WebSocket disconnection no longer emits the `DISCONNECT` event, but the new `CLIENT_DISCONNECTED` event.
+
+### Added
+- New `CLIENT_CONNECTED` event is emitted when a WebSocket client connects.
+- WebSocket client identification in disconnect log statements.
+
 ---
 
 ## v0.3.2 - 2025-09-17

--- a/ucapi/api_definitions.py
+++ b/ucapi/api_definitions.py
@@ -82,13 +82,23 @@ class WsMsgEvents(str, Enum):
 class Events(str, Enum):
     """Internal library events."""
 
+    CLIENT_CONNECTED = "client_connected"
+    """WebSocket client connected."""
+    CLIENT_DISCONNECTED = "client_disconnected"
+    """WebSocket client disconnected."""
     ENTITY_ATTRIBUTES_UPDATED = "entity_attributes_updated"
     SUBSCRIBE_ENTITIES = "subscribe_entities"
+    """Integration API `subscribe_events` message."""
     UNSUBSCRIBE_ENTITIES = "unsubscribe_entities"
+    """Integration API `unsubscribe_events` message."""
     CONNECT = "connect"
+    """Integration-API `connect` event message."""
     DISCONNECT = "disconnect"
+    """Integration-API `disconnect` event message."""
     ENTER_STANDBY = "enter_standby"
+    """Integration-API `enter_standby` event message."""
     EXIT_STANDBY = "exit_standby"
+    """Integration-API `exit_standby` event message."""
 
 
 # Does EventCategory need to be public?


### PR DESCRIPTION
The `disconnect` event is defined in the Integration-API and may not be used to signal a WebSocket disconnection.
New events have been introduced to listen to WS connections and disconnections and a new `client_count` property to get the number of clients.

Discovered in https://github.com/unfoldedcircle/integration-denonavr/issues/137