### PR TITLE
fix: Set changed size during iteration for WS broadcast

### DIFF
--- a/ucapi/api.py
+++ b/ucapi/api.py
@@ -273,7 +273,7 @@ class IntegrationAPI:
         data = {"kind": "event", "msg": msg, "msg_data": msg_data, "cat": category}
         data_dump = json.dumps(data)
 
-        for websocket in self._clients:
+        for websocket in self._clients.copy():
             if _LOG.isEnabledFor(logging.DEBUG):
                 _LOG.debug(
                     "[%s] =>: %s", websocket.remote_address, filter_log_msg_data(data)


### PR DESCRIPTION
In `_broadcast_ws_event`, the code iterates over `self._clients` directly. Since `await websocket.send()` yields control to the event loop, it is possible for a connection to close and be removed from `self._clients` (in `_handle_ws`) while the loop in `_broadcast_ws_event` is running. This causes a RuntimeError: Set changed size during iteration.

Fixes #28