### PR TITLE
refactor: optional event loop argument in IntegrationAPI constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Optional event loop argument in IntegrationAPI constructor.
+
 ---
 
 ## v0.5.0 - 2025-12-17

--- a/ucapi/api.py
+++ b/ucapi/api.py
@@ -75,13 +75,14 @@ class IntegrationAPI:
 
     DEFAULT_VOICE_SESSION_TIMEOUT_S: int = 30
 
-    def __init__(self, loop: AbstractEventLoop):
+    def __init__(self, loop: AbstractEventLoop | None = None):
         """
         Create an integration driver API instance.
 
-        :param loop: event loop
+        :param loop: optional event loop. The currently running event loop is used if
+                     not provided.
         """
-        self._loop = loop
+        self._loop = loop if loop else asyncio.get_event_loop()
         self._events = AsyncIOEventEmitter(self._loop)
 
         self._setup_handler: uc.SetupHandler | None = None


### PR DESCRIPTION
If an event loop is not provided, it is automatically retrieved with `asyncio.get_event_loop()`. This allows easier client usage.