### PR TITLE
fix: Fix the signature of the CommandHandler type

### DIFF
--- a/ucapi/api_definitions.py
+++ b/ucapi/api_definitions.py
@@ -205,6 +205,7 @@ class SetupComplete(SetupAction):
 
 
 CommandHandler: TypeAlias = Callable[
+    [Any, str, dict[str, Any] | None], Awaitable[StatusCodes] |
     [Any, str, dict[str, Any] | None, Any | None], Awaitable[StatusCodes]
 ]
 """Entity command handler signature.


### PR DESCRIPTION
This PR introduces a second signature for the CommandHandler, to make it more clear, that the `websocket` argument is really optional.

The motivation of this PR is to get rid of following type related warnings from your IDE of choice:
<img width="1142" height="210" alt="grafik" src="https://github.com/user-attachments/assets/10916b03-5ca9-4fb8-b304-d7c56199b771" />

