### PR TITLE
fix: voice session cleanup

### DIFF
--- a/ucapi/api.py
+++ b/ucapi/api.py
@@ -620,7 +620,7 @@ class IntegrationAPI:
                 session.end(VoiceEndReason.ERROR, ex)
         finally:
             # Ensure iterator is unblocked and session is cleaned up
-            await self._cleanup_voice_session(session.session_id)
+            await self._cleanup_voice_session(session.key)
 
     def _schedule_voice_timeout(self, key: VoiceSessionKey) -> None:
         """Schedule the timeout task for a voice session.


### PR DESCRIPTION
Correctly remove the voice session when the voice handler finishes.