### PR TITLE
Workaround for web-configurator hangs in setup flow

### DIFF
--- a/ucapi/api.py
+++ b/ucapi/api.py
@@ -1303,12 +1303,14 @@ class IntegrationAPI:
             )
 
             if isinstance(action, uc.RequestUserInput):
+                await asyncio.sleep(0.5)
                 await self.driver_setup_progress(websocket)
                 await self.request_driver_setup_user_input(
                     websocket, action.title, action.settings
                 )
                 result = True
             elif isinstance(action, uc.RequestUserConfirmation):
+                await asyncio.sleep(0.5)
                 await self.driver_setup_progress(websocket)
                 await self.request_driver_setup_user_confirmation(
                     websocket, action.title, action.header, action.image, action.footer


### PR DESCRIPTION
I noticed the web-configurator can get stuck in the integration setup flow in certain cases. It happens when the first initial setup of an integration is canceled or errors/times out, then restarted by clicking on its tile in the web configurator. If the integration then requests a user input or user confirmation screen, the web UI will hang until it times out.

This is easily reproduced with the setup_flow example:

1. Run the setup_flow.py example as an external integration.
2. Use the web configurator to add it to a remote that doesn't have it yet.
3. When the initial setup screen with "Configure enhanced options" appears, click the X to close it.
4. Click the "Setup Flow Demo" integration tile to start setup again.
5. Enable "Configure enhanced options" and click next. The web UI will spin on "Setting Up..." until it times out.

I saw the existing sleep calls and comments in the setup flow code that imply they're workarounds for the web-configurator, so I tried that here, and it worked. So maybe it's acceptable for a pull request!

Interestingly, I also tested this using the setup_flow example in the [node integration library](https://github.com/unfoldedcircle/integration-node-library), but I couldn't reproduce it consistently.